### PR TITLE
0.1.1/fix/carousel styling layout

### DIFF
--- a/src/components/TourCarousel.tsx
+++ b/src/components/TourCarousel.tsx
@@ -70,7 +70,7 @@ const TourCarousel = ({
   }
 
   const slideWidth = widthPercentage(86);
-  const itemHorizontalMargin = widthPercentage(8);
+  const itemHorizontalMargin = widthPercentage(10);
 
   const itemWidth = slideWidth + itemHorizontalMargin * 2;
 

--- a/src/components/TourCarousel.tsx
+++ b/src/components/TourCarousel.tsx
@@ -69,8 +69,8 @@ const TourCarousel = ({
     setCurrentSlideNumber(activeSlideIndex + 1);
   }
 
-  const slideWidth = widthPercentage(86);
-  const itemHorizontalMargin = widthPercentage(10);
+  const slideWidth = widthPercentage(84);
+  const itemHorizontalMargin = widthPercentage(8);
 
   const itemWidth = slideWidth + itemHorizontalMargin * 2;
 
@@ -106,6 +106,11 @@ const TourCarousel = ({
             (progressValue.value = absoluteProgress)
           }
           mode={'parallax'}
+          modeConfig={{
+            parallaxScrollingOffset: 100,
+            parallaxScrollingScale: 0.8,
+            parallaxAdjacentItemScale: 0.55,
+          }}
           data={data}
           renderItem={({ item }): JSX.Element => (
             <Slides

--- a/src/components/TourCarousel.tsx
+++ b/src/components/TourCarousel.tsx
@@ -69,7 +69,7 @@ const TourCarousel = ({
     setCurrentSlideNumber(activeSlideIndex + 1);
   }
 
-  const slideWidth = widthPercentage(84);
+  const slideWidth = widthPercentage(86);
   const itemHorizontalMargin = widthPercentage(8);
 
   const itemWidth = slideWidth + itemHorizontalMargin * 2;


### PR DESCRIPTION
Fixed ui issue with the side carousels offsetting to the sides.

### Before

<img src="https://github.com/CPKVG/react-native-tour-carousel/assets/51846930/bf4ce8cf-f51d-494d-b812-eb372dd62da2" height="600">

----------------------------------------
### After


<img src="https://github.com/CPKVG/react-native-tour-carousel/assets/51846930/3965b9ed-d2a4-4909-94f3-b0c4e273f7f7"  height="600">
